### PR TITLE
Fix for MAX_RESPONSE_LENGTH 

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ async function main() {
             askQuestion(question, interaction, async (content) => {
                 console.log("Response    : " + content.response);
                 console.log("---------------End---------------");
-                if (content.length >= process.env.DISCORD_MAX_RESPONSE_LENGTH) {
+                if (content.response.length >= process.env.DISCORD_MAX_RESPONSE_LENGTH) {
                     await interaction.editReply({ content: "The answer to this question is very long, so I'll answer by DM." });
                     splitAndSendResponse(content.response, interaction.user);
                 } else {


### PR DESCRIPTION
I got this error because the response was bigger than 2000 in length:
```javascript
errors: {
      content: {
        _errors: [
          {
            code: 'BASE_TYPE_MAX_LENGTH',
            message: 'Must be 2000 or fewer in length.'
          }
        ]
    }
},
```
Example prompt: `Give me an essay about Super Mario where the content of your response is 2200 characters`

I fixed it by just changing `content.length` to `content.response.length` and now it correctly sends me the response as PM instead.